### PR TITLE
Override the names of the home repos

### DIFF
--- a/data/project.json
+++ b/data/project.json
@@ -114,5 +114,17 @@
     {
       "CodePlexProject": "http://katanaproject.codeplex.com",
       "Contributor" : "Microsoft"
+    },
+    {
+      "GithubOrg": "dotnet",
+      "GithubRepo": "home",
+      "Contributor" : ".NET Foundation",
+      "Name": ".NET Foundation Home",
+    },
+    {
+      "GithubOrg": "aspnet",
+      "GithubRepo": "Home",
+      "Contributor" : "Microsoft",
+      "Name": "ASP.NET Home",
     }
 ]


### PR DESCRIPTION
Rich Turner (@bitcrazed) emailed @shanselman with the following:

> Is there any chance the .Net Foundation and ASP.Net org's could rename their “Home” repo’s to “.Net Foundation” and “Asp.Net” or similar? 
> 
> The reason is that the repo’s show up as “Home” on Microsoft’s GitHub.io page (see image attached) and also [prefixed] to the subject line of emails received from GitHub when watching a repo - this makes it difficult to filter conversations from each community into appropriate email folders!

Well, this doesn't solve either issue @bitcrazed mentions, it would disambiguate the repos in the http://dotnet.github.io website.

Do we want to take this or do we want to have a bit of a re-think about the naming and purpose of the Home repos. Thought we could use this PR to discuss.
