### PR TITLE
Override the names of the home repos

### DIFF
--- a/data/project.json
+++ b/data/project.json
@@ -121,5 +121,17 @@
     {
       "CodePlexProject": "http://phone.codeplex.com",
       "Contributor" : "Microsoft"
+    },
+    {
+      "GithubOrg": "dotnet",
+      "GithubRepo": "home",
+      "Contributor" : ".NET Foundation",
+      "Name": ".NET Foundation Home",
+    },
+    {
+      "GithubOrg": "aspnet",
+      "GithubRepo": "Home",
+      "Contributor" : "Microsoft",
+      "Name": "ASP.NET Home",
     }
 ]


### PR DESCRIPTION
DotNet and ASPNET orgs in GitHub both have Home repos. Add a more
descriptive name to disambiguate.
