### PR TITLE
Make prompt text non-selectable

### DIFF
--- a/styles/coreclr/coreclr.css
+++ b/styles/coreclr/coreclr.css
@@ -206,6 +206,12 @@ footer > .inner-footer a:hover {
   border-bottom-right-radius: 5px;
 }
 .prompt {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;  
   color: #c0c0c0;
 }
 .windows-prompt:after {


### PR DESCRIPTION
Add CSS rules to make the prompt non-selectable in the 
"Getting started" terminal commands.

Fix #13 
