### PR TITLE
Fixes for recieved feedback

### DIFF
--- a/_includes/core/footer.html
+++ b/_includes/core/footer.html
@@ -6,15 +6,15 @@
         <span class="fa fa-square-o fa-stack-2x"></span>
         <span class="fa fa-github fa-stack-1x"></span>
       </span></a>
-      <a href="https://twitter.com/microsoft" target="_blank"><span class="fa fa-stack fa-lg">
+      <a href="https://twitter.com/dotnet" target="_blank"><span class="fa fa-stack fa-lg">
         <span class="fa fa-square-o fa-stack-2x"></span>
         <span class="fa fa-twitter fa-stack-1x"></span>
       </span></a>
-      <a href="https://www.facebook.com/Microsoft" target="_blank"><span class="fa fa-stack fa-lg">
+      <a href="https://www.facebook.com/dotnet" target="_blank"><span class="fa fa-stack fa-lg">
         <span class="fa fa-square-o fa-stack-2x"></span>
         <span class="fa fa-facebook fa-stack-1x"></span>
       </span></a>
-    
+
     </p>
     </div>
 </footer>

--- a/core/about.md
+++ b/core/about.md
@@ -8,7 +8,7 @@ title: About .NET Core
 You can read more about .NET in the [.NET Primer](http://dotnet.readthedocs.org/en/latest/concepts/primer.html).
 
 ## About .NET Core
-.NET Core is a cross-platform implementation of .NET that is primarily being driven by ASP.NET 5 workloads, but also by the need and desire to have a pay-as-you-go modern runtime that you can customize . You can learn more about .NET Core and how and where you can use it in the [CoreCLR is open source](http://blogs.msdn.com/b/dotnet/archive/2015/02/03/coreclr-is-now-open-source.aspx) blog post.
+.NET Core is a cross-platform implementation of .NET that is primarily being driven by ASP.NET 5 workloads, but also by the need and desire to have a modern runtime that is modular and whose features and libraries can be cherry picked based on the application's needs. You can learn more about .NET Core and how and where you can use it in the [CoreCLR is open source](http://blogs.msdn.com/b/dotnet/archive/2015/02/03/coreclr-is-now-open-source.aspx) blog post.
 
 .NET Core consists of the [CoreCLR](https://github.com/dotnet/coreclr) runtime and the [CoreFX](https://github.com/dotnet/corefx) framework libraries. The [Roslyn compiler](https://github.com/dotnet/roslyn) and [LLILC compiler](https://github.com/dotnet/llilc) are sibling projects that support .NET Core. These projects are active on GitHub. You can participate by creating issues or collaborate on development. The main goal of the project is to create a modular, performant and cross-platform execution environment for modern applications.  
 


### PR DESCRIPTION
- Link on the Twitter badge in footer is now to @dotnet instead of
  @microsoft.
- The about page now doesn't use "pay-as-you-go" wording
  (see https://twitter.com/ericlaw/status/610614314613870592)

/cc @richlander @terrajobst 
