### PR TITLE
update link to BOTR

### DIFF
--- a/core/documentation/index.md
+++ b/core/documentation/index.md
@@ -11,7 +11,7 @@ MSDN is always a very good first stop for any documentation needs you may have. 
 ## .NET Core documentation
 Currently, we are building out a new set of documents that is covering the .NET Core scenarios and features. You can take a look at the current set of finished articles on [.NET Core ReadTheDocs](http://dotnet.readthedocs.org/en/latest/) project. As we are working towards building out this documentation corpus, there will be more additions and fixes to this set of documents. Of course, it is all open source, so you can also contribute to the documentation on GitHub.
 
-You can also visit our [GitHub repo](https://github.com/dotnet/coreclr/tree/master/Documentation) documentation and get introduced to the project. I would suggest reading through the excellent ["Book of the Runtime"](https://github.com/dotnet/coreclr/blob/master/Documentation/botr-faq.md), especially if you are interested in the more low-level technical details.
+You can also visit our [GitHub repo](https://github.com/dotnet/coreclr/tree/master/Documentation) documentation and get introduced to the project. I would suggest reading through the excellent ["Book of the Runtime"](https://github.com/dotnet/coreclr/blob/master/Documentation/botr/botr-faq.md), especially if you are interested in the more low-level technical details.
 
 ### DNX documentation
 .NET Version Manager (DNVM) and .NET Execution Environment (DNX) are very important parts of the new .NET ecosystem, especially if you wish to work with .NET Core. The [documentation](http://dotnet.readthedocs.org/en/latest/dnx/index.html) on these components can help you understand the details and how they are used, especially the [overview document](http://dotnet.readthedocs.org/en/latest/dnx/overview.html).


### PR DESCRIPTION
The "Book of the Runtime" link in the documentation is out-of-date and needs to be brought in sync with the actual location of the docs.
