### PR TITLE
Add UG aggregator to the front page of site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ _site/
 #Gemfile
 Gemfile
 Gemfile.lock
+
+# Gvim files
+*.swp
+*.*~

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
 					<span class="topnav_item"><a href="#other-sites">Sites</a></span>
 					<span class="topnav_item"><a href="#contributors">Contributors</a></span>
 					<span class="topnav_item"><a href="/about/">About</a></span>
+                    <span class="topnav_item"><a href="#ugs">Meetings</a></span>
 				</p>
 			</div>
 
@@ -36,6 +37,7 @@
 	</div>
 
 <!-- search  -->
+<div id="projectsFragment">
 	<div class="search_outer">
 		<div class="search_inner">
 			<div class="">
@@ -257,7 +259,7 @@
 	</div>
 	</div>
 <!-- end projects  -->
-
+</div>
 
 <!-- participate  -->
 	<a id="participate" ></a>
@@ -295,6 +297,36 @@
 		</div>
 	</div>
 <!-- end other sites  -->
+
+<!-- UG meetings  -->
+	<a id="ugs" ></a>
+	<div class="ugs_outer" id="ugsFragment">
+		<div class="participate_inner">
+			<div class="participate_inner_tagline">
+                See upcoming .NET UG meetings
+			</div>
+			<div class="ugs_items_outer">
+                <div id="ugResults">
+                    <!-- ko if: !loaded -->
+                        <div id="ugLoader">Loading...</div>
+                    <!-- /ko -->
+                    <div id="meetup-table" data-bind="if: loaded">
+                        <table class="ug_table table-hover">
+                            <tbody data-bind="foreach: events">
+                                <tr>
+                                    <td data-bind="text: dateTime"></td>
+                                    <td><img data-bind="attr: { src: source().image }" class="ug-badge" /></td>
+                                    <td><a data-bind="attr: { href: url }, text: name"></a></td>
+                                    <td><a data-bind="attr: { href: orgGroup().url }, text: orgGroup().name"></a></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+			</div>
+		</div>
+	</div>
+<!-- end UG meetings  -->
 
 
 <!-- contributors  -->
@@ -351,6 +383,7 @@
 <script src="js/require.config.js"></script>
 <script src="js/projects.js"></script>
 <script src="js/site.js"></script>
+<script src="js/meetup.js"></script>
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/js/meetup.js
+++ b/js/meetup.js
@@ -1,0 +1,78 @@
+require(["ko", "jquery", "moment"] , function (ko, $, moment){
+	
+	var EventGroup = function (sourceObj) {
+		//TODO add the checking logic here or something
+		this.name = ko.observable(sourceObj.group_name);
+		this.url = ko.observable(sourceObj.group_url);
+	};
+	
+	var EventSource = function(sourceObj) {
+		this.name = ko.observable();
+		this.image = ko.observable();
+		var cmLogo = "http://dotnetsocialweb.azurewebsites.net/assets/cm_logo.png";
+	    var mLogo =  "http://dotnetsocialweb.azurewebsites.net/assets/meetup_logo.png";
+	    var dLogo =  "http://dotnetsocialweb.azurewebsites.net/assets/net_logo.png";
+		
+		switch (sourceObj.source) {
+			case "meetup.com":
+				this.name("meetup");
+				this.image(mLogo); 
+				break;
+			case "communitymegaphone.com":
+				this.name("communitymegaphone");
+				this.image(cmLogo);
+				break;
+			default: 
+				this.name("none");
+				this.image(dLogo);
+				break;
+		}
+	};
+	
+	var Event = function(sourceObj) {
+		this.name = ko.observable(sourceObj.name);
+		this.url = ko.observable(sourceObj.event_url === "" ? "https://twitter.com/DotNet/dotnet-user-groups" : sourceObj.event_url);
+		this.description = ko.observable(sourceObj.description);
+		this.source = ko.observable(new EventSource(sourceObj));
+		this.dateTime = ko.observable(moment(sourceObj.time).format('dddd, MMMM Do YYYY'));
+		this.orgGroup = ko.observable(new EventGroup(sourceObj));
+		
+	};
+	
+	var ugAggregatorViewModel = {
+	    // defaultUrl :"https://twitter.com/DotNet/dotnet-user-groups",
+	    cmBaseUrl : "http://www.communitymegaphone.com",
+	    meetupBaseUrl: "http://www.meetup.com/",
+		loaded: ko.observable(false),
+		events: ko.observableArray(),
+		meetupCount: ko.observable(10),
+		loadEvents: function () {
+			 var self = this;
+			 $.ajax({
+				 url: "http://dotnetsocial.cloudapp.net/api/meetup",
+				 method: "GET",
+				 data: { count: self.meetupCount(), expiry: 60 }
+			 })
+			 .done(function (data) {
+				 console.log(data);
+				 if (data.length > 0){
+					 var tempResult = [];
+					 $.each(data, function (key, value) {
+						 console.log(value);
+						 tempResult.push(new Event(value));
+					 });
+					 self.events(tempResult);
+					 console.log(self.events());
+					 self.loaded(true);
+				 }
+			 })
+			 .fail(function (data) {
+				console.log(data); 
+			 });
+			 
+		 }
+	};
+	ugAggregatorViewModel.loadEvents();
+	ko.applyBindings(ugAggregatorViewModel, document.getElementById("ugsFragment"));
+	
+});

--- a/js/site.js
+++ b/js/site.js
@@ -81,7 +81,8 @@ require(["jquery"], function ($) {
 				viewModel.selectedCountFilter.subscribe(viewModel.filter);				
 				viewModel.selectedTimeFilter.subscribe(viewModel.filterByTime);
 				//console.log("apply bindings");
-				ko.applyBindings(viewModel);
+				//ko.applyBindings(viewModel);
+                ko.applyBindings(viewModel, document.getElementById("projectsFragment"));
 				config = false;
 				configureCountFilter(data.Projects.length);
 				filterProjects();				

--- a/styles/main/dotNetMain.css
+++ b/styles/main/dotNetMain.css
@@ -837,3 +837,29 @@ td.starback_statDescription {
 	margin:2px 0px 0px 6px;
 	background-position:0px -16px;
 }
+
+/* UG stuff styles */
+.ug-badge {
+    width: 40px;
+}
+.ugs_outer {
+	position:relative;
+	width: 100%;
+	background-color:#682079;
+	padding:0px;
+	margin:0px;
+	border-top: 4px solid #1e1e1e;
+}    
+.ugs_items_outer {
+	margin:0px auto;
+	padding:22px 0px 0px 0px;
+    color: #fff
+}
+.ug_table {
+    width: 90%;
+    margin: auto;
+}
+.ug_table > tbody > tr > td {
+    padding: 5px;
+}
+


### PR DESCRIPTION
Current incarnation of the UG aggregator added to the front page.
Some changes were needed for both site.js and meetup.js in order to
enable multiple view models for a single page. This version still
depends on the existing meetup/cm service in the cloud.

/cc @martinwoodward @richlander 
