### PR TITLE
add serialization trouble shooter page

### DIFF
--- a/native/troubleshooter/serialization.html
+++ b/native/troubleshooter/serialization.html
@@ -1,0 +1,178 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>SerializationCodeIsMissingForType troubleshooter</title>
+    <link rel="stylesheet" href="app.css" type="text/css" />
+    <script src="rdgenerate.js"></script>
+</head>
+<body onload="javascript:run(); dataContext['degreeValue']='Required All';">
+
+    <div class="container">
+        <h1>SerializationCodeIsMissingForType troubleshooter</h1>
+
+        <p>
+            The .NET Native framework has 3 built-in serializers, namely XmlSerializer, DataContractSerializer, and DataContractJsonSerializer. 
+            These serializers are non-reflection based serializers, relying on the .NET Native compiler to do the analysis of the application and 
+            generate the required serialization code for each type which it can detect is serialized and deserialized at runtime. 
+        </p>
+
+        <p>
+            In some scenarios the .NET Native compiler cannot detect that a particular type is used in serialization. Your app will encounter an 
+            InvalidDataContractException with SerializationCodeIsMissingForType exception at runtime if it attempts to serialize or deserialize a type 
+            with missing serialization code. In those cases, you need to describe the root serialization type by means of a Runtime Directive.
+        </p>
+
+        <a href="#" onclick="javascript:toggle('directivesDescription', this)" class="expandable">What are runtime directives?</a>
+
+        <div id="directivesDescription" class="collapsed">
+            <img src="default-directives.png" class="screenshot-right" width="278" height="218" />
+
+            <p>
+                Runtime Directives provide a way for you to describe what types and members your app needs to have available for reflection purposes. The
+                directives are kept in an XML file with an RD.XML extension that is part of your application package. A default RD.XML file is added to
+                all new universal app projects - look for it in the Properties node (My Project node for Visual Basic) of the Solution Explorer.
+                You can add new runtime directives to it when needed.
+            </p>
+
+            <p>
+                If you're a library author that needs to describe the use of serialization within the library, you can embed a Runtime Directives files
+                in your library. Simply add a file with an RD.XML extension to your library project, right-click the file in the Solution Explorer
+                window and select Properties. Set the <i>Build Action</i> property to <i>Embedded Resource</i> and you're good to go.
+            </p>
+
+            <p>To learn more about the RD.XML syntax, see <a href="https://msdn.microsoft.com/en-us/library/dn600639(v=vs.110).aspx">RD.XML Reference</a>.</p>
+
+            <div class="clear"></div>
+
+            <h2>Runtime Directive builder tool</h2>
+            <p>
+                The builder below will help you create a directive that will solve the SerializationCodeIsMissingForType error you're facing.
+                Use the information in the error message along with your knowledge of the code that hit the exception
+                to pick the right answers. If the error message doesn't have helpful information, make sure to rebuild
+                in Debug mode <i>with</i> .NET Native optimization enabled.
+            </p>
+        </div>
+    </div>
+    <!-- /container -->
+
+    <div class="clear"></div>
+
+    <div class="rd-builder">
+
+        <div class="wizard" id="scrollingPart">
+            <div class="wizard-panel">
+                <div class="wizard-panel-heading">I serialize/deserialize</div>
+                <div class="wizard-panel-content">
+                    <div class="input-group">
+                        <div class="input-group-addon" ms-rd-inputgroup="type">
+                            <input type="radio" ms-rd-bind="bind" name="kind" value="type" />
+                        </div>
+                        <div class="input-group-content" ms-rd-inputgroup="type">
+                            <p><strong>A single type</strong></p>
+                            <p>There's no pattern. A single type with the following name:</p>
+                            <input type="text"
+                                ms-rd-bind="bind"
+                                ms-rd-inputgroup="type"
+                                id="typeName"
+                                placeholder="example: MyType" />
+                        </div>
+                    </div>
+                    <!-- /input-group -->
+                    <div class="input-group">
+                        <div class="input-group-addon" ms-rd-inputgroup="namespace">
+                            <input type="radio" ms-rd-bind="bind" name="kind" value="namespace" />
+                        </div>
+                        <div class="input-group-content" ms-rd-inputgroup="namespace">
+                            <p><strong>All types in a namespace</strong></p>
+                            <p>All types within the following namespace:</p>
+                            <input type="text"
+                                ms-rd-bind="bind"
+                                ms-rd-inputgroup="namespace"
+                                id="namespaceName"
+                                placeholder="example: MyNamespace" />
+                        </div>
+                    </div>
+                    <!-- /input-group -->
+                    <div class="input-group">
+                        <div class="input-group-addon" ms-rd-inputgroup="assembly">
+                            <input type="radio" ms-rd-bind="bind" name="kind" value="assembly" />
+                        </div>
+                        <div class="input-group-content" ms-rd-inputgroup="assembly">
+                            <p><strong>All types in an assembly</strong></p>
+                            <p>All types in the following assembly:</p>
+                            <input type="text"
+                                ms-rd-bind="bind"
+                                ms-rd-inputgroup="assembly"
+                                id="assemblyName"
+                                placeholder="example: MyAssembly" />
+                        </div>
+                    </div>
+                    <!-- /input-group -->
+                </div>
+                <!-- /wizard-panel-content -->
+            </div>
+            <!-- /wizard-panel -->
+            <div class="wizard-panel">
+                <div class="wizard-panel-heading">I use</div>
+
+                <div class="wizard-panel-content">
+                    <div class="input-group">
+                        <div class="input-group-addon" ms-rd-inputgroup="DataContractSerializer">
+                            <input type="radio" ms-rd-bind="bind" name="degreeName" value="DataContractSerializer" />
+                        </div>
+                        <div class="input-group-content" ms-rd-inputgroup="DataContractSerializer">
+                            <p><strong>DataContractSerializer</strong></p>
+                        </div>
+                    </div>
+                    <!-- /input-group -->
+
+                    <div class="input-group">
+                        <div class="input-group-addon" ms-rd-inputgroup="DataContractJsonSerializer">
+                            <input type="radio" ms-rd-bind="bind" name="degreeName" value="DataContractJsonSerializer" />
+                        </div>
+                        <div class="input-group-content" ms-rd-inputgroup="DataContractJsonSerializer">
+                            <p><strong>DataContractJsonSerializer</strong></p>
+                        </div>
+                    </div>
+                    <!-- /input-group -->
+
+                    <div class="input-group">
+                        <div class="input-group-addon" ms-rd-inputgroup="XmlSerializer">
+                            <input type="radio" ms-rd-bind="bind" name="degreeName" value="XmlSerializer" />
+                        </div>
+                        <div class="input-group-content" ms-rd-inputgroup="XmlSerializer">
+                            <p><strong>XmlSerializer</strong></p>
+                        </div>
+                    </div>
+                    <!-- /input-group -->
+                </div>
+                <!-- /wizard-panel-content -->
+            </div>
+            <!-- /wizard-panel -->
+        </div>
+        <!-- /wizard -->
+        <div class="preview" id="fixedPart">
+            <div class="preview-panel">
+                <div class="preview-panel-heading">Preview</div>
+                <div class="preview-panel-content">
+                    <p>
+                        This preview shows you the runtime directive corresponding to the choices
+                        you made in the left column. If you're adding a directive to an existing RD.XML file,
+                        append the directives under the <code>&lt;Application&gt;</code> element to the <code>&lt;Application&gt;</code>
+                        element of the existing RD.XML.
+                    </p>
+
+                    <p>If you are authoring an RD.XML for a library, replace <code>&lt;Application&gt;</code>  with <code>&lt;Library&gt;</code> .</p>
+
+                    <div class="preview-xml" id="preview"></div>
+                </div>
+            </div>
+        </div>
+        <div class="clear"></div>
+    </div>
+    <!-- rd-builder -->
+    <p class="copyright">&copy;2015 Microsoft</p>
+</body>
+</html>


### PR DESCRIPTION
If a type cannot be serialized because the serialization code is missing, the FwLink in the exception message points the user to the RD.XML File Reference on MSDN. There’s nothing inherently wrong with that – after reading through the 11 screens of text and clicking through a few subpages, the user will find what they need to do.

This troubleshooter page is to help the developer fix this kind of issues with less effort.
