### PR TITLE
Core gs update

### DIFF
--- a/_includes/core/linux_gs.html
+++ b/_includes/core/linux_gs.html
@@ -10,23 +10,6 @@
           <p><span class="prompt unix-prompt"></span>sudo apt-get install libunwind8 libssl-dev unzip libicu-dev</p>
         </div>
       </div>
-      <p>Secondly, we need to install <a href="http://www.mono-project.com">Mono</a>, which is needed to support the NuGet client for package management (a temporary requirement for now).</p>
-      <div class="terminal">
-        <div class="terminal-titlebar"></div>
-        <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF </p>
-          <p><span class="prompt unix-prompt"></span>echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list </p>
-          <p><span class="prompt unix-prompt"></span>sudo apt-get update</p>
-          <p><span class="prompt unix-prompt"></span>sudo apt-get install mono-complete </p>
-        </div>
-      </div>
-      <p>Finally, import required certificates for NuGet packages.</p>
-      <div class="terminal">
-        <div class="terminal-titlebar"></div>
-        <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>mozroots --import --sync </p>
-        </div>
-      </div>
     </div>
     <div class="step step-none linux-trail" id="step-2">
       <div class="step-number">2</div>
@@ -93,14 +76,11 @@
     <div class="step step-none linux-trail" id="step-5">
       <div class="step-number">5</div>
       <h3>Run the app</h3>
-      <p>The first command switches over to Mono to restore the packages, which is what the second command does using <strong>project.json</strong>. We then switch back to CoreCLR and run our app.</p>
-      <p>Do not forget to replace &quot;[version]&quot; with the version DNVM installed on your machine; you can get a list of those by doing <strong>dnvm list</strong>.
+      <p>First, we restore the packages using the <strong>dnu</strong> command and then we run the application!</p>
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>dnvm use [version] -r mono</p>
           <p><span class="prompt unix-prompt"></span>dnu restore</p>
-          <p><span class="prompt unix-prompt"></span>dnvm use [version] -r coreclr</p>
           <p><span class="prompt unix-prompt"></span> dnx run</p>
         </div>
       </div>

--- a/_includes/core/linux_gs.html
+++ b/_includes/core/linux_gs.html
@@ -7,7 +7,7 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>sudo apt-get install libunwind8 libssl-dev unzip </p>
+          <p><span class="prompt unix-prompt"></span>sudo apt-get install libunwind8 libssl-dev unzip libicu-dev</p>
         </div>
       </div>
       <p>Secondly, we need to install <a href="http://www.mono-project.com">Mono</a>, which is needed to support the NuGet client for package management (a temporary requirement for now).</p>

--- a/_includes/core/macosx_gs.html
+++ b/_includes/core/macosx_gs.html
@@ -1,8 +1,19 @@
 <!-- MAC OSX GETTING STARTED -->
-    <div class="step step-none macosx-trail" id="step-1">
-      <div class="step-number">1</div>
+<div class="step step-none macosx-trail" id="step-1">      
+    <div class="step-number">1</div>
+      <h3>Prepare the environment</h3>
+      <p>We need to make sure we have all of the dependencies set up. Installing them is a breeze using <a href="http://www.brew.sh/" target="_blank">Homebrew</a>.</p>
+      <div class="terminal">
+        <div class="terminal-titlebar"></div>
+        <div class="terminal-body">
+          <p><span class="prompt unix-prompt"></span>brew install icu4c</p>
+        </div>
+      </div>
+</div>
+<div class="step step-none macosx-trail" id="step-2">
+      <div class="step-number">2</div>
       <h3>Install .NET Version Manager (DNVM)</h3>
-      <p>DNVM is a script that will help us manage execution environments that we will use. Installing it is a breeze using <a href="http://www.brew.sh/" target="_blank">Homebrew</a>. After installing, we register the dnvm command. </p>
+      <p>DNVM is a script that will help us manage execution environments that we will use.  After installing, we register the dnvm command. </p>
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
@@ -13,8 +24,8 @@
         </div>
       </div>
     </div>
-    <div class="step step-none macosx-trail" id="step-2">
-      <div class="step-number">2</div>
+    <div class="step step-none macosx-trail" id="step-3">
+      <div class="step-number">3</div>
       <h3>Install .NET Core Execution Environment (DNX)</h3>
       <p>Next step is to install the execution environment that will run Core CLR code:</p>
       <div class="terminal">
@@ -26,8 +37,8 @@
       </div>
     </div>
 
-    <div class="step step-none macosx-trail" id="step-3">
-      <div class="step-number">3</div>
+    <div class="step step-none macosx-trail" id="step-4">
+      <div class="step-number">4</div>
       <h3>Write the app</h3>
       <p>Create a new file <strong>HelloWorld.cs</strong> in a directory, and paste in the code below:</p>
       <div class="terminal">
@@ -64,17 +75,14 @@
 
     </div>
 
-    <div class="step step-none macosx-trail" id="step-4">
-      <div class="step-number">4</div>
+    <div class="step step-none macosx-trail" id="step-5">
+      <div class="step-number">5</div>
       <h3>Run the app</h3>
-      <p>The first command switches over to Mono to restore the packages, which is what the second command does using <strong>project.json</strong>. We then switch back to CoreCLR and run our app.</p>
-      <p>Do not forget to replace &quot;[version]&quot; with the version DNVM installed on your machine; you can get a list of those by doing <strong>dnvm list</strong>.
+      <p>The first command will restore the packages specified in the <strong>project.json</strong> file, and the second command will run the actuall sample:</p>
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>dnvm use [version] -r mono</p>
           <p><span class="prompt unix-prompt"></span>dnu restore</p>
-          <p><span class="prompt unix-prompt"></span>dnvm use [version] -r coreclr</p>
           <p><span class="prompt unix-prompt"></span> dnx run</p>
         </div>
       </div>


### PR DESCRIPTION
Fixing the getting started instructions for OS X and Linux, since new dependencies were brought on with beta 8, and Mono is not a requirement anymore. 

/cc @richlander 
