### PR TITLE
Update Linux required packages for DNX beta8

### DIFF
--- a/_includes/core/linux_gs.html
+++ b/_includes/core/linux_gs.html
@@ -7,7 +7,7 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>sudo apt-get install libunwind8 libssl-dev unzip </p>
+          <p><span class="prompt unix-prompt"></span>sudo apt-get install libunwind8 gettext libssl-dev unzip libcurl3-dev zlib1g libicu-dev</p>
         </div>
       </div>
       <p>Secondly, we need to install <a href="http://www.mono-project.com">Mono</a>, which is needed to support the NuGet client for package management (a temporary requirement for now).</p>


### PR DESCRIPTION
The Linux "Getting Started" steps are out-of-date with respect to DNX beta8 and recent dev builds. A few new packages are required to be installed.

See https://github.com/aspnet/dnx/issues/3059

/cc @danroth27 @davidfowl @moozzyk
