### PR TITLE
Fix typo in windows_gs.html

### DIFF
--- a/_includes/gs/windows_gs.html
+++ b/_includes/gs/windows_gs.html
@@ -63,7 +63,7 @@
     <div class="step step-none windows-trail" id="step-4">
       <div class="step-number">4</div>
       <h3>Run the app</h3>
-      <p>The first command will restore the packages specified in the <strong>project.json</strong> file, and the second command will run the actuall sample:</p>
+      <p>The first command will restore the packages specified in the <strong>project.json</strong> file, and the second command will run the actual sample:</p>
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">


### PR DESCRIPTION
Fixing a spelling error in Windows Getting Started doc: "actuall" -> "actual"
