### PR TITLE
Add redirects

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-inverse navbar-fixed-top">
      <div class="container">
-       <a href="../index.html"><img height="50px" src="{{ pathPrefix }}../images/Logo_DotNet.png" style="float:right;"/></a>
+       <a href="http://www.dotnetfoundation.org/"><img height="50px" src="{{ pathPrefix }}../images/Logo_DotNet.png" style="float:right;"/></a>
        <div class="navbar-header ">
          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
            <span class="sr-only">Toggle navigation</span>

--- a/core/getting-started/index.html
+++ b/core/getting-started/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <meta http-equiv="refresh" content="0; url=/getting-started/" />
+    </head>
+    <body>
+        <p><strong>This page has changed locations</strong></p>
+    </body>
+</html>
+

--- a/core/index.html
+++ b/core/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <meta http-equiv="refresh" content="0; url=/" />
+    </head>
+    <body>
+        <p><strong>This page has changed locations</strong></p>
+    </body>
+</html>


### PR DESCRIPTION
To avoid confusion, add redirects from /core/ and /core/getting-started/ paths to the new site. These two paths were chose because they are the two most used in other online properties. 

Also link the .NET Foundation logo to the .NET Foundation actual site. 

/cc @richlander @BethMassi 
