### PR TITLE
Remove Mozilla dotted border on GS buttons

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -23,6 +23,7 @@ h1, h2, h3, h4, h5 {
   font-weight: bold;
 }
 
+
 footer {
   text-align: center;
   width: 100%;
@@ -41,6 +42,7 @@ footer > .inner-footer a:hover {
   /*color: #A979B3;*/
     color: #A356B3;
   text-decoration: none;
+  outline: 0;
 }
 .content a:hover {
   /*transition: color .15s cubic-bezier(.33, .66, .66, 1);*/
@@ -116,6 +118,7 @@ footer > .inner-footer a:hover {
 .btn-gs:hover, .btn-gs:active, .btn-gs:focus, .jquery-active {
   color: #fff;
   background-color: #682079;
+  outline: 0 !important;
 }
 
 


### PR DESCRIPTION
Remove the dotted borders in Firefox & Crhome around the getting
started buttons.

Fix #18
