### PR TITLE
`dotnet init` is the correct command

### DIFF
--- a/_includes/gs/macosx_gs.html
+++ b/_includes/gs/macosx_gs.html
@@ -11,7 +11,7 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>dotnet new</p>
+          <p><span class="prompt unix-prompt"></span>dotnet init</p>
         </div>
       </div>
 


### PR DESCRIPTION
`dotnet new` causes the exception reported in dotnet/cli#420
