### PR TITLE
Fix package name and add symlink instruction for Ubuntu 14.04

### DIFF
--- a/_includes/gs/linux_gs.html
+++ b/_includes/gs/linux_gs.html
@@ -22,9 +22,19 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>sudo apt-get install dotnet</p>
+          <p><span class="prompt unix-prompt"></span>sudo apt-get install dotnet-nightly</p>
         </div>
       </div>
+      <p>There is currently an issue with the APT package, which creates a directory
+        called `/usr/share/dotnet-nightly` where the runtime is expecting `/usr/share/dotnet`.
+        You can work around this for now by creating a symlink with the correct name, as shown
+        below.</p>
+        <div class="terminal">
+          <div class="terminal-titlebar"></div>
+          <div class="terminal-body">
+            <p><span class="prompt unix-prompt"></span>sudo ln -s /usr/share/dotnet-nightly /usr/share/dotnet</p>
+          </div>
+        </div>
     </div>
     <div class="step step-none linux-trail" id="step-3">
       <div class="step-number">3</div>


### PR DESCRIPTION
I had a fun half-hour getting up and running on Ubuntu, so I fixed up the Getting Started instructions.
