### PR TITLE
Homepage's hero disappears because homepage's url changes to / in jekyll 3.0

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -9,7 +9,7 @@
   <!-- include navigation here -->
   {% include navigation.html %}
   <!-- include hero here if the page is index -->
-  {% if page.url == '/index.html' %}
+  {% if page.url == '/' %}
     {% include hero.html %}
   {% endif %}
 


### PR DESCRIPTION
FYI, https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0
@blackdwarf 
