### PR TITLE
Fixing the GS content

### DIFF
--- a/_includes/gs/linux_gs.html
+++ b/_includes/gs/linux_gs.html
@@ -4,14 +4,14 @@
       <div class="step-number">1</div>
       <h3>Add the new apt-get feed</h3>
       <p>In order to install .NET Core on Ubuntu, we need to first set up the apt-get feed that hosts the package we need.</p>
-      <p><strong>Note:</strong> as of now, the below instructions work on Ubuntu 14.04 and derivatives. New versions are coming up soon!</p>
+      <p><strong>Note:</strong> as of now, the below instructions work on Ubuntu 14.04 and derivatives. New versions are coming up soon! Also, please be aware that this feed is our development feed. As we stabilize we will change feeds where deb packages are stored.</p>
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
+          <p>sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 </p>
-          <p><span class="prompt unix-prompt"></span>sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893</p>
-          <p><span class="prompt unix-prompt"></span>sudo apt-get update</p>
+          <p>sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893</p>
+          <p>sudo apt-get update</p>
         </div>
       </div>
     </div>
@@ -19,11 +19,10 @@
       <div class="step-number">2</div>
       <h3>Install .NET Core</h3>
       <p>Installing .NET Core is a simple thing on Ubuntu. The below will install the package and all of its dependencies.</p>
-      <p><strong>Note:</strong> please note that currently the only available package is the nightly build. As we progress to our Beta release, we will have the dotnet package back up.</p>
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>sudo apt-get install dotnet-nightly</p>
+          <p>sudo apt-get install dotnet=1.0.0.001331-1</p>
         </div>
       </div>
     </div>
@@ -34,7 +33,9 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>dotnet new</p>
+            <p>mkdir hwapp</p>
+            <p>cd hwapp</p>
+            <p>dotnet new</p>
         </div>
       </div>
     </div>
@@ -46,8 +47,8 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>dotnet restore</p>
-          <p><span class="prompt unix-prompt"></span>dotnet run</p>
+          <p>dotnet restore</p>
+          <p>dotnet run</p>
         </div>
       </div>
     </div>

--- a/_includes/gs/macosx_gs.html
+++ b/_includes/gs/macosx_gs.html
@@ -2,7 +2,7 @@
     <div class="step step-none macosx-trail" id="step-1">      
         <div class="step-number">1</div>
           <h3>Use the official PKG</h3>
-          <p>The best way to install .NET Core on OS X is to use the <a href="https://dotnetcli.blob.core.windows.net/dotnet/dev/Installers/Latest/dotnet-osx-x64.latest.pkg">official PKG package</a>. This installer will install the tools and put them on your PATH.</p>
+          <p>The best way to install .NET Core on OS X is to use the <a href="https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-osx-x64.latest.pkg">official PKG package</a>. This installer will install the tools and put them on your PATH.</p>
     </div>
     <div class="step step-none macosx-trail" id="step-2">
       <div class="step-number">2</div>
@@ -11,7 +11,9 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>dotnet new</p>
+            <p>mkdir hwapp</p>
+            <p>cd hwapp</p>
+          <p>dotnet new</p>
         </div>
       </div>
 
@@ -24,8 +26,8 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt unix-prompt"></span>dotnet restore</p>
-          <p><span class="prompt unix-prompt"></span>dotnet run</p>
+          <p>dotnet restore</p>
+          <p>dotnet run</p>
         </div>
       </div>
 

--- a/_includes/gs/windows_gs.html
+++ b/_includes/gs/windows_gs.html
@@ -12,7 +12,9 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt windows-prompt"></span>dotnet new</p>
+            <p>mkdir hwapp</p>
+            <p>cd hwapp</p>
+          <p>dotnet new</p>
         </div>
       </div>
     </div>
@@ -24,8 +26,8 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p><span class="prompt windows-prompt"></span>dotnet restore</p>
-          <p><span class="prompt windows-prompt"></span>dotnet run</p>
+          <p>dotnet restore</p>
+          <p>dotnet run</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Pointing the links for OS X and Windows to LKG builds.
Adding LKG version to the Ubuntu install instructions.
