### PR TITLE
Fixing links to point to a LKG

### DIFF
--- a/_includes/gs/linux_gs.html
+++ b/_includes/gs/linux_gs.html
@@ -22,7 +22,7 @@
       <div class="terminal">
         <div class="terminal-titlebar"></div>
         <div class="terminal-body">
-          <p>sudo apt-get install dotnet=1.0.0.001331-1</p>
+          <p>sudo apt-get install dotnet=1.0.0.001598-1</p>
         </div>
       </div>
     </div>

--- a/_includes/gs/macosx_gs.html
+++ b/_includes/gs/macosx_gs.html
@@ -2,7 +2,7 @@
     <div class="step step-none macosx-trail" id="step-1">      
         <div class="step-number">1</div>
           <h3>Use the official PKG</h3>
-          <p>The best way to install .NET Core on OS X is to use the <a href="https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-osx-x64.latest.pkg">official PKG package</a>. This installer will install the tools and put them on your PATH.</p>
+          <p>The best way to install .NET Core on OS X is to use the <a href="https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/1.0.0.001598/dotnet-osx-x64.1.0.0.001598.pkg">official PKG package</a>. This installer will install the tools and put them on your PATH.</p>
     </div>
     <div class="step step-none macosx-trail" id="step-2">
       <div class="step-number">2</div>

--- a/_includes/gs/windows_gs.html
+++ b/_includes/gs/windows_gs.html
@@ -2,7 +2,7 @@
     <div class="step step-none windows-trail" id="step-1">
       <div class="step-number">1</div>
       <h3>Install .NET Core</h3>
-      <p>The best way to install .NET Core on Windows is to download the <a href="https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-win-x64.latest.exe">official MSI installer</a>. This installer will install the tools and put them on your PATH.</p>
+      <p>The best way to install .NET Core on Windows is to download the <a href="https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/1.0.0.001598/dotnet-win-x64.1.0.0.001598.exe">official MSI installer</a>. This installer will install the tools and put them on your PATH.</p>
       <p>If you are using Windows 7, Windows Server 2008 or Windows Server 2012 you will also need to install <a href="https://www.microsoft.com/en-us/download/confirmation.aspx?id=30679">Visual C++ Redistributable for Visual Studio 2012 Update 4</a> &amp; <a href="https://www.microsoft.com/en-us/download/details.aspx?id=48145">Visual C++ Redistributable for Visual Studio 2015
 </a>.</p>
   </div>


### PR DESCRIPTION
Merge only after the OS X PKG versioned name is fixed in the CLI repo. 
